### PR TITLE
Bump text upper version bounds

### DIFF
--- a/ghcjs-dom.cabal
+++ b/ghcjs-dom.cabal
@@ -39,7 +39,7 @@ flag gtk3
 library
     build-depends: base <5,
                    mtl -any,
-                   text >= 0.11.0.6 && < 1.2
+                   text >= 0.11.0.6 && < 1.3
 
     default-language: Haskell2010
     exposed-modules:


### PR DESCRIPTION
Part of my efforts to get `leksah` to compile using the latest packages.
