### PR TITLE
Add Eq instances

### DIFF
--- a/src/GHCJS/DOM/Types.hs
+++ b/src/GHCJS/DOM/Types.hs
@@ -374,7 +374,7 @@ type FromDOMString s = GlibString s
 -- AUTO GENERATION STARTS HERE
 -- The remainder of this file is generated from IDL files using domconv-webkit-jsffi
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype DOMAttr = DOMAttr (JSRef DOMAttr)
+newtype DOMAttr = DOMAttr (JSRef DOMAttr) deriving (Eq)
 
 unDOMAttr (DOMAttr o) = o
 
@@ -407,7 +407,7 @@ type IsDOMAttr o = DOMAttrClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype BarProp = BarProp (JSRef BarProp)
+newtype BarProp = BarProp (JSRef BarProp) deriving (Eq)
 
 unBarProp (BarProp o) = o
 
@@ -438,7 +438,7 @@ gTypeBarProp = GType gTypeBarProp'
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype Blob = Blob (JSRef Blob)
+newtype Blob = Blob (JSRef Blob) deriving (Eq)
 
 unBlob (Blob o) = o
 
@@ -470,7 +470,7 @@ type IsBlob o = BlobClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype CDATASection = CDATASection (JSRef CDATASection)
+newtype CDATASection = CDATASection (JSRef CDATASection) deriving (Eq)
 
 unCDATASection (CDATASection o) = o
 
@@ -505,7 +505,7 @@ type IsCDATASection o = CDATASectionClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype CSSRule = CSSRule (JSRef CSSRule)
+newtype CSSRule = CSSRule (JSRef CSSRule) deriving (Eq)
 
 unCSSRule (CSSRule o) = o
 
@@ -537,7 +537,7 @@ type IsCSSRule o = CSSRuleClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype CSSRuleList = CSSRuleList (JSRef CSSRuleList)
+newtype CSSRuleList = CSSRuleList (JSRef CSSRuleList) deriving (Eq)
 
 unCSSRuleList (CSSRuleList o) = o
 
@@ -569,7 +569,7 @@ type IsCSSRuleList o = CSSRuleListClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype CSSStyleDeclaration = CSSStyleDeclaration (JSRef CSSStyleDeclaration)
+newtype CSSStyleDeclaration = CSSStyleDeclaration (JSRef CSSStyleDeclaration) deriving (Eq)
 
 unCSSStyleDeclaration (CSSStyleDeclaration o) = o
 
@@ -601,7 +601,7 @@ type IsCSSStyleDeclaration o = CSSStyleDeclarationClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype CSSStyleSheet = CSSStyleSheet (JSRef CSSStyleSheet)
+newtype CSSStyleSheet = CSSStyleSheet (JSRef CSSStyleSheet) deriving (Eq)
 
 unCSSStyleSheet (CSSStyleSheet o) = o
 
@@ -634,7 +634,7 @@ type IsCSSStyleSheet o = CSSStyleSheetClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype CSSValue = CSSValue (JSRef CSSValue)
+newtype CSSValue = CSSValue (JSRef CSSValue) deriving (Eq)
 
 unCSSValue (CSSValue o) = o
 
@@ -666,7 +666,7 @@ type IsCSSValue o = CSSValueClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype CharacterData = CharacterData (JSRef CharacterData)
+newtype CharacterData = CharacterData (JSRef CharacterData) deriving (Eq)
 
 unCharacterData (CharacterData o) = o
 
@@ -699,7 +699,7 @@ type IsCharacterData o = CharacterDataClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype Comment = Comment (JSRef Comment)
+newtype Comment = Comment (JSRef Comment) deriving (Eq)
 
 unComment (Comment o) = o
 
@@ -733,7 +733,7 @@ type IsComment o = CommentClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype DOMApplicationCache = DOMApplicationCache (JSRef DOMApplicationCache)
+newtype DOMApplicationCache = DOMApplicationCache (JSRef DOMApplicationCache) deriving (Eq)
 
 unDOMApplicationCache (DOMApplicationCache o) = o
 
@@ -765,7 +765,7 @@ type IsDOMApplicationCache o = DOMApplicationCacheClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype DOMImplementation = DOMImplementation (JSRef DOMImplementation)
+newtype DOMImplementation = DOMImplementation (JSRef DOMImplementation) deriving (Eq)
 
 unDOMImplementation (DOMImplementation o) = o
 
@@ -797,7 +797,7 @@ type IsDOMImplementation o = DOMImplementationClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype DOMMimeType = DOMMimeType (JSRef DOMMimeType)
+newtype DOMMimeType = DOMMimeType (JSRef DOMMimeType) deriving (Eq)
 
 unDOMMimeType (DOMMimeType o) = o
 
@@ -829,7 +829,7 @@ type IsDOMMimeType o = DOMMimeTypeClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype DOMMimeTypeArray = DOMMimeTypeArray (JSRef DOMMimeTypeArray)
+newtype DOMMimeTypeArray = DOMMimeTypeArray (JSRef DOMMimeTypeArray) deriving (Eq)
 
 unDOMMimeTypeArray (DOMMimeTypeArray o) = o
 
@@ -861,7 +861,7 @@ type IsDOMMimeTypeArray o = DOMMimeTypeArrayClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype DOMNamedFlowCollection = DOMNamedFlowCollection (JSRef DOMNamedFlowCollection)
+newtype DOMNamedFlowCollection = DOMNamedFlowCollection (JSRef DOMNamedFlowCollection) deriving (Eq)
 
 unDOMNamedFlowCollection (DOMNamedFlowCollection o) = o
 
@@ -892,7 +892,7 @@ gTypeDOMNamedFlowCollection = GType gTypeDOMNamedFlowCollection'
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype DOMPlugin = DOMPlugin (JSRef DOMPlugin)
+newtype DOMPlugin = DOMPlugin (JSRef DOMPlugin) deriving (Eq)
 
 unDOMPlugin (DOMPlugin o) = o
 
@@ -924,7 +924,7 @@ type IsDOMPlugin o = DOMPluginClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype DOMPluginArray = DOMPluginArray (JSRef DOMPluginArray)
+newtype DOMPluginArray = DOMPluginArray (JSRef DOMPluginArray) deriving (Eq)
 
 unDOMPluginArray (DOMPluginArray o) = o
 
@@ -956,7 +956,7 @@ type IsDOMPluginArray o = DOMPluginArrayClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype DOMSecurityPolicy = DOMSecurityPolicy (JSRef DOMSecurityPolicy)
+newtype DOMSecurityPolicy = DOMSecurityPolicy (JSRef DOMSecurityPolicy) deriving (Eq)
 
 unDOMSecurityPolicy (DOMSecurityPolicy o) = o
 
@@ -987,7 +987,7 @@ gTypeDOMSecurityPolicy = GType gTypeDOMSecurityPolicy'
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype DOMSelection = DOMSelection (JSRef DOMSelection)
+newtype DOMSelection = DOMSelection (JSRef DOMSelection) deriving (Eq)
 
 unDOMSelection (DOMSelection o) = o
 
@@ -1019,7 +1019,7 @@ type IsDOMSelection o = DOMSelectionClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype DOMSettableTokenList = DOMSettableTokenList (JSRef DOMSettableTokenList)
+newtype DOMSettableTokenList = DOMSettableTokenList (JSRef DOMSettableTokenList) deriving (Eq)
 
 unDOMSettableTokenList (DOMSettableTokenList o) = o
 
@@ -1052,7 +1052,7 @@ type IsDOMSettableTokenList o = DOMSettableTokenListClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype DOMStringList = DOMStringList (JSRef DOMStringList)
+newtype DOMStringList = DOMStringList (JSRef DOMStringList) deriving (Eq)
 
 unDOMStringList (DOMStringList o) = o
 
@@ -1084,7 +1084,7 @@ type IsDOMStringList o = DOMStringListClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype DOMTokenList = DOMTokenList (JSRef DOMTokenList)
+newtype DOMTokenList = DOMTokenList (JSRef DOMTokenList) deriving (Eq)
 
 unDOMTokenList (DOMTokenList o) = o
 
@@ -1116,7 +1116,7 @@ type IsDOMTokenList o = DOMTokenListClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype DOMWindow = DOMWindow (JSRef DOMWindow)
+newtype DOMWindow = DOMWindow (JSRef DOMWindow) deriving (Eq)
 
 unDOMWindow (DOMWindow o) = o
 
@@ -1148,7 +1148,7 @@ type IsDOMWindow o = DOMWindowClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype DOMWindowCSS = DOMWindowCSS (JSRef DOMWindowCSS)
+newtype DOMWindowCSS = DOMWindowCSS (JSRef DOMWindowCSS) deriving (Eq)
 
 unDOMWindowCSS (DOMWindowCSS o) = o
 
@@ -1179,7 +1179,7 @@ gTypeDOMWindowCSS = GType gTypeDOMWindowCSS'
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype Document = Document (JSRef Document)
+newtype Document = Document (JSRef Document) deriving (Eq)
 
 unDocument (Document o) = o
 
@@ -1212,7 +1212,7 @@ type IsDocument o = DocumentClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype DocumentFragment = DocumentFragment (JSRef DocumentFragment)
+newtype DocumentFragment = DocumentFragment (JSRef DocumentFragment) deriving (Eq)
 
 unDocumentFragment (DocumentFragment o) = o
 
@@ -1245,7 +1245,7 @@ type IsDocumentFragment o = DocumentFragmentClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype DocumentType = DocumentType (JSRef DocumentType)
+newtype DocumentType = DocumentType (JSRef DocumentType) deriving (Eq)
 
 unDocumentType (DocumentType o) = o
 
@@ -1278,7 +1278,7 @@ type IsDocumentType o = DocumentTypeClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype Element = Element (JSRef Element)
+newtype Element = Element (JSRef Element) deriving (Eq)
 
 unElement (Element o) = o
 
@@ -1311,7 +1311,7 @@ type IsElement o = ElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype EntityReference = EntityReference (JSRef EntityReference)
+newtype EntityReference = EntityReference (JSRef EntityReference) deriving (Eq)
 
 unEntityReference (EntityReference o) = o
 
@@ -1344,7 +1344,7 @@ type IsEntityReference o = EntityReferenceClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype Event = Event (JSRef Event)
+newtype Event = Event (JSRef Event) deriving (Eq)
 
 unEvent (Event o) = o
 
@@ -1376,7 +1376,7 @@ type IsEvent o = EventClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype EventTarget = EventTarget (JSRef EventTarget)
+newtype EventTarget = EventTarget (JSRef EventTarget) deriving (Eq)
 
 unEventTarget (EventTarget o) = o
 
@@ -1408,7 +1408,7 @@ type IsEventTarget o = EventTargetClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype File = File (JSRef File)
+newtype File = File (JSRef File) deriving (Eq)
 
 unFile (File o) = o
 
@@ -1441,7 +1441,7 @@ type IsFile o = FileClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype FileList = FileList (JSRef FileList)
+newtype FileList = FileList (JSRef FileList) deriving (Eq)
 
 unFileList (FileList o) = o
 
@@ -1473,7 +1473,7 @@ type IsFileList o = FileListClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype Geolocation = Geolocation (JSRef Geolocation)
+newtype Geolocation = Geolocation (JSRef Geolocation) deriving (Eq)
 
 unGeolocation (Geolocation o) = o
 
@@ -1505,7 +1505,7 @@ type IsGeolocation o = GeolocationClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLAnchorElement = HTMLAnchorElement (JSRef HTMLAnchorElement)
+newtype HTMLAnchorElement = HTMLAnchorElement (JSRef HTMLAnchorElement) deriving (Eq)
 
 unHTMLAnchorElement (HTMLAnchorElement o) = o
 
@@ -1540,7 +1540,7 @@ type IsHTMLAnchorElement o = HTMLAnchorElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLAppletElement = HTMLAppletElement (JSRef HTMLAppletElement)
+newtype HTMLAppletElement = HTMLAppletElement (JSRef HTMLAppletElement) deriving (Eq)
 
 unHTMLAppletElement (HTMLAppletElement o) = o
 
@@ -1575,7 +1575,7 @@ type IsHTMLAppletElement o = HTMLAppletElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLAreaElement = HTMLAreaElement (JSRef HTMLAreaElement)
+newtype HTMLAreaElement = HTMLAreaElement (JSRef HTMLAreaElement) deriving (Eq)
 
 unHTMLAreaElement (HTMLAreaElement o) = o
 
@@ -1610,7 +1610,7 @@ type IsHTMLAreaElement o = HTMLAreaElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLAudioElement = HTMLAudioElement (JSRef HTMLAudioElement)
+newtype HTMLAudioElement = HTMLAudioElement (JSRef HTMLAudioElement) deriving (Eq)
 
 unHTMLAudioElement (HTMLAudioElement o) = o
 
@@ -1646,7 +1646,7 @@ type IsHTMLAudioElement o = HTMLAudioElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLBRElement = HTMLBRElement (JSRef HTMLBRElement)
+newtype HTMLBRElement = HTMLBRElement (JSRef HTMLBRElement) deriving (Eq)
 
 unHTMLBRElement (HTMLBRElement o) = o
 
@@ -1681,7 +1681,7 @@ type IsHTMLBRElement o = HTMLBRElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLBaseElement = HTMLBaseElement (JSRef HTMLBaseElement)
+newtype HTMLBaseElement = HTMLBaseElement (JSRef HTMLBaseElement) deriving (Eq)
 
 unHTMLBaseElement (HTMLBaseElement o) = o
 
@@ -1716,7 +1716,7 @@ type IsHTMLBaseElement o = HTMLBaseElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLBaseFontElement = HTMLBaseFontElement (JSRef HTMLBaseFontElement)
+newtype HTMLBaseFontElement = HTMLBaseFontElement (JSRef HTMLBaseFontElement) deriving (Eq)
 
 unHTMLBaseFontElement (HTMLBaseFontElement o) = o
 
@@ -1751,7 +1751,7 @@ type IsHTMLBaseFontElement o = HTMLBaseFontElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLBodyElement = HTMLBodyElement (JSRef HTMLBodyElement)
+newtype HTMLBodyElement = HTMLBodyElement (JSRef HTMLBodyElement) deriving (Eq)
 
 unHTMLBodyElement (HTMLBodyElement o) = o
 
@@ -1786,7 +1786,7 @@ type IsHTMLBodyElement o = HTMLBodyElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLButtonElement = HTMLButtonElement (JSRef HTMLButtonElement)
+newtype HTMLButtonElement = HTMLButtonElement (JSRef HTMLButtonElement) deriving (Eq)
 
 unHTMLButtonElement (HTMLButtonElement o) = o
 
@@ -1821,7 +1821,7 @@ type IsHTMLButtonElement o = HTMLButtonElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLCanvasElement = HTMLCanvasElement (JSRef HTMLCanvasElement)
+newtype HTMLCanvasElement = HTMLCanvasElement (JSRef HTMLCanvasElement) deriving (Eq)
 
 unHTMLCanvasElement (HTMLCanvasElement o) = o
 
@@ -1856,7 +1856,7 @@ type IsHTMLCanvasElement o = HTMLCanvasElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLCollection = HTMLCollection (JSRef HTMLCollection)
+newtype HTMLCollection = HTMLCollection (JSRef HTMLCollection) deriving (Eq)
 
 unHTMLCollection (HTMLCollection o) = o
 
@@ -1888,7 +1888,7 @@ type IsHTMLCollection o = HTMLCollectionClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLDListElement = HTMLDListElement (JSRef HTMLDListElement)
+newtype HTMLDListElement = HTMLDListElement (JSRef HTMLDListElement) deriving (Eq)
 
 unHTMLDListElement (HTMLDListElement o) = o
 
@@ -1923,7 +1923,7 @@ type IsHTMLDListElement o = HTMLDListElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLDetailsElement = HTMLDetailsElement (JSRef HTMLDetailsElement)
+newtype HTMLDetailsElement = HTMLDetailsElement (JSRef HTMLDetailsElement) deriving (Eq)
 
 unHTMLDetailsElement (HTMLDetailsElement o) = o
 
@@ -1958,7 +1958,7 @@ type IsHTMLDetailsElement o = HTMLDetailsElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLDirectoryElement = HTMLDirectoryElement (JSRef HTMLDirectoryElement)
+newtype HTMLDirectoryElement = HTMLDirectoryElement (JSRef HTMLDirectoryElement) deriving (Eq)
 
 unHTMLDirectoryElement (HTMLDirectoryElement o) = o
 
@@ -1993,7 +1993,7 @@ type IsHTMLDirectoryElement o = HTMLDirectoryElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLDivElement = HTMLDivElement (JSRef HTMLDivElement)
+newtype HTMLDivElement = HTMLDivElement (JSRef HTMLDivElement) deriving (Eq)
 
 unHTMLDivElement (HTMLDivElement o) = o
 
@@ -2028,7 +2028,7 @@ type IsHTMLDivElement o = HTMLDivElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLDocument = HTMLDocument (JSRef HTMLDocument)
+newtype HTMLDocument = HTMLDocument (JSRef HTMLDocument) deriving (Eq)
 
 unHTMLDocument (HTMLDocument o) = o
 
@@ -2062,7 +2062,7 @@ type IsHTMLDocument o = HTMLDocumentClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLElement = HTMLElement (JSRef HTMLElement)
+newtype HTMLElement = HTMLElement (JSRef HTMLElement) deriving (Eq)
 
 unHTMLElement (HTMLElement o) = o
 
@@ -2096,7 +2096,7 @@ type IsHTMLElement o = HTMLElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLEmbedElement = HTMLEmbedElement (JSRef HTMLEmbedElement)
+newtype HTMLEmbedElement = HTMLEmbedElement (JSRef HTMLEmbedElement) deriving (Eq)
 
 unHTMLEmbedElement (HTMLEmbedElement o) = o
 
@@ -2131,7 +2131,7 @@ type IsHTMLEmbedElement o = HTMLEmbedElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLFieldSetElement = HTMLFieldSetElement (JSRef HTMLFieldSetElement)
+newtype HTMLFieldSetElement = HTMLFieldSetElement (JSRef HTMLFieldSetElement) deriving (Eq)
 
 unHTMLFieldSetElement (HTMLFieldSetElement o) = o
 
@@ -2166,7 +2166,7 @@ type IsHTMLFieldSetElement o = HTMLFieldSetElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLFontElement = HTMLFontElement (JSRef HTMLFontElement)
+newtype HTMLFontElement = HTMLFontElement (JSRef HTMLFontElement) deriving (Eq)
 
 unHTMLFontElement (HTMLFontElement o) = o
 
@@ -2201,7 +2201,7 @@ type IsHTMLFontElement o = HTMLFontElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLFormElement = HTMLFormElement (JSRef HTMLFormElement)
+newtype HTMLFormElement = HTMLFormElement (JSRef HTMLFormElement) deriving (Eq)
 
 unHTMLFormElement (HTMLFormElement o) = o
 
@@ -2236,7 +2236,7 @@ type IsHTMLFormElement o = HTMLFormElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLFrameElement = HTMLFrameElement (JSRef HTMLFrameElement)
+newtype HTMLFrameElement = HTMLFrameElement (JSRef HTMLFrameElement) deriving (Eq)
 
 unHTMLFrameElement (HTMLFrameElement o) = o
 
@@ -2271,7 +2271,7 @@ type IsHTMLFrameElement o = HTMLFrameElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLFrameSetElement = HTMLFrameSetElement (JSRef HTMLFrameSetElement)
+newtype HTMLFrameSetElement = HTMLFrameSetElement (JSRef HTMLFrameSetElement) deriving (Eq)
 
 unHTMLFrameSetElement (HTMLFrameSetElement o) = o
 
@@ -2306,7 +2306,7 @@ type IsHTMLFrameSetElement o = HTMLFrameSetElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLHRElement = HTMLHRElement (JSRef HTMLHRElement)
+newtype HTMLHRElement = HTMLHRElement (JSRef HTMLHRElement) deriving (Eq)
 
 unHTMLHRElement (HTMLHRElement o) = o
 
@@ -2341,7 +2341,7 @@ type IsHTMLHRElement o = HTMLHRElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLHeadElement = HTMLHeadElement (JSRef HTMLHeadElement)
+newtype HTMLHeadElement = HTMLHeadElement (JSRef HTMLHeadElement) deriving (Eq)
 
 unHTMLHeadElement (HTMLHeadElement o) = o
 
@@ -2376,7 +2376,7 @@ type IsHTMLHeadElement o = HTMLHeadElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLHeadingElement = HTMLHeadingElement (JSRef HTMLHeadingElement)
+newtype HTMLHeadingElement = HTMLHeadingElement (JSRef HTMLHeadingElement) deriving (Eq)
 
 unHTMLHeadingElement (HTMLHeadingElement o) = o
 
@@ -2411,7 +2411,7 @@ type IsHTMLHeadingElement o = HTMLHeadingElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLHtmlElement = HTMLHtmlElement (JSRef HTMLHtmlElement)
+newtype HTMLHtmlElement = HTMLHtmlElement (JSRef HTMLHtmlElement) deriving (Eq)
 
 unHTMLHtmlElement (HTMLHtmlElement o) = o
 
@@ -2446,7 +2446,7 @@ type IsHTMLHtmlElement o = HTMLHtmlElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLIFrameElement = HTMLIFrameElement (JSRef HTMLIFrameElement)
+newtype HTMLIFrameElement = HTMLIFrameElement (JSRef HTMLIFrameElement) deriving (Eq)
 
 unHTMLIFrameElement (HTMLIFrameElement o) = o
 
@@ -2481,7 +2481,7 @@ type IsHTMLIFrameElement o = HTMLIFrameElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLImageElement = HTMLImageElement (JSRef HTMLImageElement)
+newtype HTMLImageElement = HTMLImageElement (JSRef HTMLImageElement) deriving (Eq)
 
 unHTMLImageElement (HTMLImageElement o) = o
 
@@ -2516,7 +2516,7 @@ type IsHTMLImageElement o = HTMLImageElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLInputElement = HTMLInputElement (JSRef HTMLInputElement)
+newtype HTMLInputElement = HTMLInputElement (JSRef HTMLInputElement) deriving (Eq)
 
 unHTMLInputElement (HTMLInputElement o) = o
 
@@ -2551,7 +2551,7 @@ type IsHTMLInputElement o = HTMLInputElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLKeygenElement = HTMLKeygenElement (JSRef HTMLKeygenElement)
+newtype HTMLKeygenElement = HTMLKeygenElement (JSRef HTMLKeygenElement) deriving (Eq)
 
 unHTMLKeygenElement (HTMLKeygenElement o) = o
 
@@ -2586,7 +2586,7 @@ type IsHTMLKeygenElement o = HTMLKeygenElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLLIElement = HTMLLIElement (JSRef HTMLLIElement)
+newtype HTMLLIElement = HTMLLIElement (JSRef HTMLLIElement) deriving (Eq)
 
 unHTMLLIElement (HTMLLIElement o) = o
 
@@ -2621,7 +2621,7 @@ type IsHTMLLIElement o = HTMLLIElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLLabelElement = HTMLLabelElement (JSRef HTMLLabelElement)
+newtype HTMLLabelElement = HTMLLabelElement (JSRef HTMLLabelElement) deriving (Eq)
 
 unHTMLLabelElement (HTMLLabelElement o) = o
 
@@ -2656,7 +2656,7 @@ type IsHTMLLabelElement o = HTMLLabelElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLLegendElement = HTMLLegendElement (JSRef HTMLLegendElement)
+newtype HTMLLegendElement = HTMLLegendElement (JSRef HTMLLegendElement) deriving (Eq)
 
 unHTMLLegendElement (HTMLLegendElement o) = o
 
@@ -2691,7 +2691,7 @@ type IsHTMLLegendElement o = HTMLLegendElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLLinkElement = HTMLLinkElement (JSRef HTMLLinkElement)
+newtype HTMLLinkElement = HTMLLinkElement (JSRef HTMLLinkElement) deriving (Eq)
 
 unHTMLLinkElement (HTMLLinkElement o) = o
 
@@ -2726,7 +2726,7 @@ type IsHTMLLinkElement o = HTMLLinkElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLMapElement = HTMLMapElement (JSRef HTMLMapElement)
+newtype HTMLMapElement = HTMLMapElement (JSRef HTMLMapElement) deriving (Eq)
 
 unHTMLMapElement (HTMLMapElement o) = o
 
@@ -2761,7 +2761,7 @@ type IsHTMLMapElement o = HTMLMapElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLMarqueeElement = HTMLMarqueeElement (JSRef HTMLMarqueeElement)
+newtype HTMLMarqueeElement = HTMLMarqueeElement (JSRef HTMLMarqueeElement) deriving (Eq)
 
 unHTMLMarqueeElement (HTMLMarqueeElement o) = o
 
@@ -2796,7 +2796,7 @@ type IsHTMLMarqueeElement o = HTMLMarqueeElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLMediaElement = HTMLMediaElement (JSRef HTMLMediaElement)
+newtype HTMLMediaElement = HTMLMediaElement (JSRef HTMLMediaElement) deriving (Eq)
 
 unHTMLMediaElement (HTMLMediaElement o) = o
 
@@ -2831,7 +2831,7 @@ type IsHTMLMediaElement o = HTMLMediaElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLMenuElement = HTMLMenuElement (JSRef HTMLMenuElement)
+newtype HTMLMenuElement = HTMLMenuElement (JSRef HTMLMenuElement) deriving (Eq)
 
 unHTMLMenuElement (HTMLMenuElement o) = o
 
@@ -2866,7 +2866,7 @@ type IsHTMLMenuElement o = HTMLMenuElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLMetaElement = HTMLMetaElement (JSRef HTMLMetaElement)
+newtype HTMLMetaElement = HTMLMetaElement (JSRef HTMLMetaElement) deriving (Eq)
 
 unHTMLMetaElement (HTMLMetaElement o) = o
 
@@ -2901,7 +2901,7 @@ type IsHTMLMetaElement o = HTMLMetaElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLModElement = HTMLModElement (JSRef HTMLModElement)
+newtype HTMLModElement = HTMLModElement (JSRef HTMLModElement) deriving (Eq)
 
 unHTMLModElement (HTMLModElement o) = o
 
@@ -2936,7 +2936,7 @@ type IsHTMLModElement o = HTMLModElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLOListElement = HTMLOListElement (JSRef HTMLOListElement)
+newtype HTMLOListElement = HTMLOListElement (JSRef HTMLOListElement) deriving (Eq)
 
 unHTMLOListElement (HTMLOListElement o) = o
 
@@ -2971,7 +2971,7 @@ type IsHTMLOListElement o = HTMLOListElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLObjectElement = HTMLObjectElement (JSRef HTMLObjectElement)
+newtype HTMLObjectElement = HTMLObjectElement (JSRef HTMLObjectElement) deriving (Eq)
 
 unHTMLObjectElement (HTMLObjectElement o) = o
 
@@ -3006,7 +3006,7 @@ type IsHTMLObjectElement o = HTMLObjectElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLOptGroupElement = HTMLOptGroupElement (JSRef HTMLOptGroupElement)
+newtype HTMLOptGroupElement = HTMLOptGroupElement (JSRef HTMLOptGroupElement) deriving (Eq)
 
 unHTMLOptGroupElement (HTMLOptGroupElement o) = o
 
@@ -3041,7 +3041,7 @@ type IsHTMLOptGroupElement o = HTMLOptGroupElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLOptionElement = HTMLOptionElement (JSRef HTMLOptionElement)
+newtype HTMLOptionElement = HTMLOptionElement (JSRef HTMLOptionElement) deriving (Eq)
 
 unHTMLOptionElement (HTMLOptionElement o) = o
 
@@ -3076,7 +3076,7 @@ type IsHTMLOptionElement o = HTMLOptionElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLOptionsCollection = HTMLOptionsCollection (JSRef HTMLOptionsCollection)
+newtype HTMLOptionsCollection = HTMLOptionsCollection (JSRef HTMLOptionsCollection) deriving (Eq)
 
 unHTMLOptionsCollection (HTMLOptionsCollection o) = o
 
@@ -3109,7 +3109,7 @@ type IsHTMLOptionsCollection o = HTMLOptionsCollectionClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLParagraphElement = HTMLParagraphElement (JSRef HTMLParagraphElement)
+newtype HTMLParagraphElement = HTMLParagraphElement (JSRef HTMLParagraphElement) deriving (Eq)
 
 unHTMLParagraphElement (HTMLParagraphElement o) = o
 
@@ -3144,7 +3144,7 @@ type IsHTMLParagraphElement o = HTMLParagraphElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLParamElement = HTMLParamElement (JSRef HTMLParamElement)
+newtype HTMLParamElement = HTMLParamElement (JSRef HTMLParamElement) deriving (Eq)
 
 unHTMLParamElement (HTMLParamElement o) = o
 
@@ -3179,7 +3179,7 @@ type IsHTMLParamElement o = HTMLParamElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLPreElement = HTMLPreElement (JSRef HTMLPreElement)
+newtype HTMLPreElement = HTMLPreElement (JSRef HTMLPreElement) deriving (Eq)
 
 unHTMLPreElement (HTMLPreElement o) = o
 
@@ -3214,7 +3214,7 @@ type IsHTMLPreElement o = HTMLPreElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLQuoteElement = HTMLQuoteElement (JSRef HTMLQuoteElement)
+newtype HTMLQuoteElement = HTMLQuoteElement (JSRef HTMLQuoteElement) deriving (Eq)
 
 unHTMLQuoteElement (HTMLQuoteElement o) = o
 
@@ -3249,7 +3249,7 @@ type IsHTMLQuoteElement o = HTMLQuoteElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLScriptElement = HTMLScriptElement (JSRef HTMLScriptElement)
+newtype HTMLScriptElement = HTMLScriptElement (JSRef HTMLScriptElement) deriving (Eq)
 
 unHTMLScriptElement (HTMLScriptElement o) = o
 
@@ -3284,7 +3284,7 @@ type IsHTMLScriptElement o = HTMLScriptElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLSelectElement = HTMLSelectElement (JSRef HTMLSelectElement)
+newtype HTMLSelectElement = HTMLSelectElement (JSRef HTMLSelectElement) deriving (Eq)
 
 unHTMLSelectElement (HTMLSelectElement o) = o
 
@@ -3319,7 +3319,7 @@ type IsHTMLSelectElement o = HTMLSelectElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLStyleElement = HTMLStyleElement (JSRef HTMLStyleElement)
+newtype HTMLStyleElement = HTMLStyleElement (JSRef HTMLStyleElement) deriving (Eq)
 
 unHTMLStyleElement (HTMLStyleElement o) = o
 
@@ -3354,7 +3354,7 @@ type IsHTMLStyleElement o = HTMLStyleElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLTableCaptionElement = HTMLTableCaptionElement (JSRef HTMLTableCaptionElement)
+newtype HTMLTableCaptionElement = HTMLTableCaptionElement (JSRef HTMLTableCaptionElement) deriving (Eq)
 
 unHTMLTableCaptionElement (HTMLTableCaptionElement o) = o
 
@@ -3389,7 +3389,7 @@ type IsHTMLTableCaptionElement o = HTMLTableCaptionElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLTableCellElement = HTMLTableCellElement (JSRef HTMLTableCellElement)
+newtype HTMLTableCellElement = HTMLTableCellElement (JSRef HTMLTableCellElement) deriving (Eq)
 
 unHTMLTableCellElement (HTMLTableCellElement o) = o
 
@@ -3424,7 +3424,7 @@ type IsHTMLTableCellElement o = HTMLTableCellElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLTableColElement = HTMLTableColElement (JSRef HTMLTableColElement)
+newtype HTMLTableColElement = HTMLTableColElement (JSRef HTMLTableColElement) deriving (Eq)
 
 unHTMLTableColElement (HTMLTableColElement o) = o
 
@@ -3459,7 +3459,7 @@ type IsHTMLTableColElement o = HTMLTableColElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLTableElement = HTMLTableElement (JSRef HTMLTableElement)
+newtype HTMLTableElement = HTMLTableElement (JSRef HTMLTableElement) deriving (Eq)
 
 unHTMLTableElement (HTMLTableElement o) = o
 
@@ -3494,7 +3494,7 @@ type IsHTMLTableElement o = HTMLTableElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLTableRowElement = HTMLTableRowElement (JSRef HTMLTableRowElement)
+newtype HTMLTableRowElement = HTMLTableRowElement (JSRef HTMLTableRowElement) deriving (Eq)
 
 unHTMLTableRowElement (HTMLTableRowElement o) = o
 
@@ -3529,7 +3529,7 @@ type IsHTMLTableRowElement o = HTMLTableRowElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLTableSectionElement = HTMLTableSectionElement (JSRef HTMLTableSectionElement)
+newtype HTMLTableSectionElement = HTMLTableSectionElement (JSRef HTMLTableSectionElement) deriving (Eq)
 
 unHTMLTableSectionElement (HTMLTableSectionElement o) = o
 
@@ -3564,7 +3564,7 @@ type IsHTMLTableSectionElement o = HTMLTableSectionElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLTextAreaElement = HTMLTextAreaElement (JSRef HTMLTextAreaElement)
+newtype HTMLTextAreaElement = HTMLTextAreaElement (JSRef HTMLTextAreaElement) deriving (Eq)
 
 unHTMLTextAreaElement (HTMLTextAreaElement o) = o
 
@@ -3599,7 +3599,7 @@ type IsHTMLTextAreaElement o = HTMLTextAreaElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLTitleElement = HTMLTitleElement (JSRef HTMLTitleElement)
+newtype HTMLTitleElement = HTMLTitleElement (JSRef HTMLTitleElement) deriving (Eq)
 
 unHTMLTitleElement (HTMLTitleElement o) = o
 
@@ -3634,7 +3634,7 @@ type IsHTMLTitleElement o = HTMLTitleElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLUListElement = HTMLUListElement (JSRef HTMLUListElement)
+newtype HTMLUListElement = HTMLUListElement (JSRef HTMLUListElement) deriving (Eq)
 
 unHTMLUListElement (HTMLUListElement o) = o
 
@@ -3669,7 +3669,7 @@ type IsHTMLUListElement o = HTMLUListElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype HTMLVideoElement = HTMLVideoElement (JSRef HTMLVideoElement)
+newtype HTMLVideoElement = HTMLVideoElement (JSRef HTMLVideoElement) deriving (Eq)
 
 unHTMLVideoElement (HTMLVideoElement o) = o
 
@@ -3705,7 +3705,7 @@ type IsHTMLVideoElement o = HTMLVideoElementClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype History = History (JSRef History)
+newtype History = History (JSRef History) deriving (Eq)
 
 unHistory (History o) = o
 
@@ -3737,7 +3737,7 @@ type IsHistory o = HistoryClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype KeyboardEvent = KeyboardEvent (JSRef KeyboardEvent)
+newtype KeyboardEvent = KeyboardEvent (JSRef KeyboardEvent) deriving (Eq)
 
 unKeyboardEvent (KeyboardEvent o) = o
 
@@ -3770,7 +3770,7 @@ gTypeKeyboardEvent = GType gTypeKeyboardEvent'
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype Location = Location (JSRef Location)
+newtype Location = Location (JSRef Location) deriving (Eq)
 
 unLocation (Location o) = o
 
@@ -3802,7 +3802,7 @@ type IsLocation o = LocationClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype MediaError = MediaError (JSRef MediaError)
+newtype MediaError = MediaError (JSRef MediaError) deriving (Eq)
 
 unMediaError (MediaError o) = o
 
@@ -3834,7 +3834,7 @@ type IsMediaError o = MediaErrorClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype MediaList = MediaList (JSRef MediaList)
+newtype MediaList = MediaList (JSRef MediaList) deriving (Eq)
 
 unMediaList (MediaList o) = o
 
@@ -3866,7 +3866,7 @@ type IsMediaList o = MediaListClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype MediaQueryList = MediaQueryList (JSRef MediaQueryList)
+newtype MediaQueryList = MediaQueryList (JSRef MediaQueryList) deriving (Eq)
 
 unMediaQueryList (MediaQueryList o) = o
 
@@ -3898,7 +3898,7 @@ type IsMediaQueryList o = MediaQueryListClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype MessagePort = MessagePort (JSRef MessagePort)
+newtype MessagePort = MessagePort (JSRef MessagePort) deriving (Eq)
 
 unMessagePort (MessagePort o) = o
 
@@ -3930,7 +3930,7 @@ type IsMessagePort o = MessagePortClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype MouseEvent = MouseEvent (JSRef MouseEvent)
+newtype MouseEvent = MouseEvent (JSRef MouseEvent) deriving (Eq)
 
 unMouseEvent (MouseEvent o) = o
 
@@ -3964,7 +3964,7 @@ type IsMouseEvent o = MouseEventClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype NamedNodeMap = NamedNodeMap (JSRef NamedNodeMap)
+newtype NamedNodeMap = NamedNodeMap (JSRef NamedNodeMap) deriving (Eq)
 
 unNamedNodeMap (NamedNodeMap o) = o
 
@@ -3996,7 +3996,7 @@ type IsNamedNodeMap o = NamedNodeMapClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype Navigator = Navigator (JSRef Navigator)
+newtype Navigator = Navigator (JSRef Navigator) deriving (Eq)
 
 unNavigator (Navigator o) = o
 
@@ -4028,7 +4028,7 @@ type IsNavigator o = NavigatorClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype Node = Node (JSRef Node)
+newtype Node = Node (JSRef Node) deriving (Eq)
 
 unNode (Node o) = o
 
@@ -4060,7 +4060,7 @@ type IsNode o = NodeClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype NodeFilter = NodeFilter (JSRef NodeFilter)
+newtype NodeFilter = NodeFilter (JSRef NodeFilter) deriving (Eq)
 
 unNodeFilter (NodeFilter o) = o
 
@@ -4092,7 +4092,7 @@ type IsNodeFilter o = NodeFilterClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype NodeIterator = NodeIterator (JSRef NodeIterator)
+newtype NodeIterator = NodeIterator (JSRef NodeIterator) deriving (Eq)
 
 unNodeIterator (NodeIterator o) = o
 
@@ -4124,7 +4124,7 @@ type IsNodeIterator o = NodeIteratorClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype NodeList = NodeList (JSRef NodeList)
+newtype NodeList = NodeList (JSRef NodeList) deriving (Eq)
 
 unNodeList (NodeList o) = o
 
@@ -4156,7 +4156,7 @@ type IsNodeList o = NodeListClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype ProcessingInstruction = ProcessingInstruction (JSRef ProcessingInstruction)
+newtype ProcessingInstruction = ProcessingInstruction (JSRef ProcessingInstruction) deriving (Eq)
 
 unProcessingInstruction (ProcessingInstruction o) = o
 
@@ -4190,7 +4190,7 @@ type IsProcessingInstruction o = ProcessingInstructionClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype DOMRange = DOMRange (JSRef DOMRange)
+newtype DOMRange = DOMRange (JSRef DOMRange) deriving (Eq)
 
 unDOMRange (DOMRange o) = o
 
@@ -4222,7 +4222,7 @@ type IsDOMRange o = DOMRangeClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype DOMScreen = DOMScreen (JSRef DOMScreen)
+newtype DOMScreen = DOMScreen (JSRef DOMScreen) deriving (Eq)
 
 unDOMScreen (DOMScreen o) = o
 
@@ -4254,7 +4254,7 @@ type IsDOMScreen o = DOMScreenClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype Storage = Storage (JSRef Storage)
+newtype Storage = Storage (JSRef Storage) deriving (Eq)
 
 unStorage (Storage o) = o
 
@@ -4286,7 +4286,7 @@ type IsStorage o = StorageClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype StorageInfo = StorageInfo (JSRef StorageInfo)
+newtype StorageInfo = StorageInfo (JSRef StorageInfo) deriving (Eq)
 
 unStorageInfo (StorageInfo o) = o
 
@@ -4317,7 +4317,7 @@ gTypeStorageInfo = GType gTypeStorageInfo'
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype StyleMedia = StyleMedia (JSRef StyleMedia)
+newtype StyleMedia = StyleMedia (JSRef StyleMedia) deriving (Eq)
 
 unStyleMedia (StyleMedia o) = o
 
@@ -4349,7 +4349,7 @@ type IsStyleMedia o = StyleMediaClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype StyleSheet = StyleSheet (JSRef StyleSheet)
+newtype StyleSheet = StyleSheet (JSRef StyleSheet) deriving (Eq)
 
 unStyleSheet (StyleSheet o) = o
 
@@ -4381,7 +4381,7 @@ type IsStyleSheet o = StyleSheetClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype StyleSheetList = StyleSheetList (JSRef StyleSheetList)
+newtype StyleSheetList = StyleSheetList (JSRef StyleSheetList) deriving (Eq)
 
 unStyleSheetList (StyleSheetList o) = o
 
@@ -4413,7 +4413,7 @@ type IsStyleSheetList o = StyleSheetListClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype Text = Text (JSRef Text)
+newtype Text = Text (JSRef Text) deriving (Eq)
 
 unText (Text o) = o
 
@@ -4447,7 +4447,7 @@ type IsText o = TextClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype TimeRanges = TimeRanges (JSRef TimeRanges)
+newtype TimeRanges = TimeRanges (JSRef TimeRanges) deriving (Eq)
 
 unTimeRanges (TimeRanges o) = o
 
@@ -4479,7 +4479,7 @@ type IsTimeRanges o = TimeRangesClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype TreeWalker = TreeWalker (JSRef TreeWalker)
+newtype TreeWalker = TreeWalker (JSRef TreeWalker) deriving (Eq)
 
 unTreeWalker (TreeWalker o) = o
 
@@ -4511,7 +4511,7 @@ type IsTreeWalker o = TreeWalkerClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype UIEvent = UIEvent (JSRef UIEvent)
+newtype UIEvent = UIEvent (JSRef UIEvent) deriving (Eq)
 
 unUIEvent (UIEvent o) = o
 
@@ -4544,7 +4544,7 @@ type IsUIEvent o = UIEventClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype ValidityState = ValidityState (JSRef ValidityState)
+newtype ValidityState = ValidityState (JSRef ValidityState) deriving (Eq)
 
 unValidityState (ValidityState o) = o
 
@@ -4576,7 +4576,7 @@ type IsValidityState o = ValidityStateClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype WebKitNamedFlow = WebKitNamedFlow (JSRef WebKitNamedFlow)
+newtype WebKitNamedFlow = WebKitNamedFlow (JSRef WebKitNamedFlow) deriving (Eq)
 
 unWebKitNamedFlow (WebKitNamedFlow o) = o
 
@@ -4608,7 +4608,7 @@ type IsWebKitNamedFlow o = WebKitNamedFlowClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype WebKitPoint = WebKitPoint (JSRef WebKitPoint)
+newtype WebKitPoint = WebKitPoint (JSRef WebKitPoint) deriving (Eq)
 
 unWebKitPoint (WebKitPoint o) = o
 
@@ -4640,7 +4640,7 @@ type IsWebKitPoint o = WebKitPointClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype XPathExpression = XPathExpression (JSRef XPathExpression)
+newtype XPathExpression = XPathExpression (JSRef XPathExpression) deriving (Eq)
 
 unXPathExpression (XPathExpression o) = o
 
@@ -4672,7 +4672,7 @@ type IsXPathExpression o = XPathExpressionClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype XPathNSResolver = XPathNSResolver (JSRef XPathNSResolver)
+newtype XPathNSResolver = XPathNSResolver (JSRef XPathNSResolver) deriving (Eq)
 
 unXPathNSResolver (XPathNSResolver o) = o
 
@@ -4704,7 +4704,7 @@ type IsXPathNSResolver o = XPathNSResolverClass o
 
 
 #if (defined(ghcjs_HOST_OS) && defined(USE_JAVASCRIPTFFI)) || !defined(USE_WEBKIT)
-newtype XPathResult = XPathResult (JSRef XPathResult)
+newtype XPathResult = XPathResult (JSRef XPathResult) deriving (Eq)
 
 unXPathResult (XPathResult o) = o
 


### PR DESCRIPTION
This adds an Eq instance to every newtype in GHCJS.DOM.Types.  This is the only way I've found to do a cross-platform equality comparison on these types that works with both GHC and GHCJS.