### PR TITLE
Finish JSRef to JSVal conversion

### DIFF
--- a/ghcjs-dom.cabal
+++ b/ghcjs-dom.cabal
@@ -1,5 +1,5 @@
 name: ghcjs-dom
-version: 0.2.2.0
+version: 0.2.3.0
 cabal-version: >=1.10
 build-type: Simple
 license: MIT


### PR DESCRIPTION
As noted in #25, #23 didn't fix. This is manually patched version of #23 that at least builds.

Didn't check if it actually works, need to migrate my project to JSVal infrastructure.