### PR TITLE
Support blobs and files in FormData.append

### DIFF
--- a/ghcjs-dom.cabal
+++ b/ghcjs-dom.cabal
@@ -568,6 +568,7 @@ library
           GHCJS.DOM.JSFFI.Database
           GHCJS.DOM.JSFFI.DOMError
           GHCJS.DOM.JSFFI.Geolocation
+          GHCJS.DOM.JSFFI.FormData
           GHCJS.DOM.JSFFI.MediaStreamTrack
           GHCJS.DOM.JSFFI.Navigator
           GHCJS.DOM.JSFFI.NavigatorUserMediaError

--- a/src/GHCJS/DOM/FormData.hs
+++ b/src/GHCJS/DOM/FormData.hs
@@ -1,4 +1,4 @@
 module GHCJS.DOM.FormData (
-  module GHCJS.DOM.JSFFI.Generated.FormData
+  module GHCJS.DOM.JSFFI.FormData
   ) where
-import GHCJS.DOM.JSFFI.Generated.FormData
+import GHCJS.DOM.JSFFI.FormData

--- a/src/GHCJS/DOM/JSFFI/FormData.hs
+++ b/src/GHCJS/DOM/JSFFI/FormData.hs
@@ -12,36 +12,37 @@ import Control.Monad.IO.Class (MonadIO(..))
 
 import GHCJS.Types (JSVal, JSString)
 import GHCJS.Marshal.Internal (PToJSVal(..))
-import GHCJS.Foreign (jsNull)
-import GHCJS.DOM.File (getName)
+import GHCJS.Foreign (jsUndefined)
 import GHCJS.DOM.Types
 
 import GHCJS.DOM.JSFFI.Generated.FormData as Generated hiding (js_append, append)
 
+
+maybeToOptional :: PToJSVal a => Maybe a -> JSVal
+maybeToOptional (Just a) = pToJSVal a
+maybeToOptional Nothing = jsUndefined
+
+
 foreign import javascript unsafe "$1[\"append\"]($2, $3, $4)"
-        js_append :: FormData -> JSString -> JSVal -> Nullable JSString -> IO ()
+        js_append :: FormData -> JSString -> JSVal -> JSVal -> IO ()
 
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/FormData/append Mozilla FormData.append documentation>
 append
   :: (MonadIO m, ToJSString name, ToJSString str)
   => FormData -> name -> str -> m ()
 append self name str
-  = liftIO $ js_append self (toJSString name) (pToJSVal str) (Nullable jsNull)
+  = liftIO $ js_append self (toJSString name) (pToJSVal str) jsUndefined
 
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/FormData/append Mozilla FormData.append documentation>
 appendBlob
   :: (MonadIO m, ToJSString name, IsBlob blob, ToJSString filename)
   => FormData -> name -> blob -> Maybe filename -> m ()
 appendBlob self name blob filename
-  = liftIO $ js_append self (toJSString name) (unBlob $ toBlob blob) $
-                Nullable $ pToJSVal $ maybe (toJSString "blob") toJSString filename
+  = liftIO $ js_append self (toJSString name) (unBlob $ toBlob blob) $ maybeToOptional $ toJSString <$> filename
 
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/FormData/append Mozilla FormData.append documentation>
 appendFile
   :: (MonadIO m, ToJSString name, ToJSString filename)
   => FormData -> name -> File -> Maybe filename -> m ()
 appendFile self name file filename
-  = liftIO $ do
-      fn <- getName file
-      js_append self (toJSString name) (unFile file) $
-          Nullable $ pToJSVal $ maybe (fn :: JSString) toJSString filename
+  = liftIO $ js_append self (toJSString name) (unFile file) $ maybeToOptional $ toJSString <$> filename

--- a/src/GHCJS/DOM/JSFFI/FormData.hs
+++ b/src/GHCJS/DOM/JSFFI/FormData.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE ForeignFunctionInterface, JavaScriptFFI #-}
+module GHCJS.DOM.JSFFI.FormData (
+    module Generated
+  , js_append
+  , append
+  , appendBlob
+  , appendFile
+) where
+
+import Prelude hiding (appendFile)
+import Control.Monad.IO.Class (MonadIO(..))
+
+import GHCJS.Types (JSVal, JSString)
+import GHCJS.Marshal.Internal (PToJSVal(..))
+import GHCJS.Foreign (jsNull)
+import GHCJS.DOM.File (getName)
+import GHCJS.DOM.Types
+
+import GHCJS.DOM.JSFFI.Generated.FormData as Generated hiding (js_append, append)
+
+foreign import javascript unsafe "$1[\"append\"]($2, $3, $4)"
+        js_append :: FormData -> JSString -> JSVal -> Nullable JSString -> IO ()
+
+-- | <https://developer.mozilla.org/en-US/docs/Web/API/FormData/append Mozilla FormData.append documentation>
+append
+  :: (MonadIO m, ToJSString name, ToJSString str)
+  => FormData -> name -> str -> m ()
+append self name str
+  = liftIO $ js_append self (toJSString name) (pToJSVal str) (Nullable jsNull)
+
+-- | <https://developer.mozilla.org/en-US/docs/Web/API/FormData/append Mozilla FormData.append documentation>
+appendBlob
+  :: (MonadIO m, ToJSString name, IsBlob blob, ToJSString filename)
+  => FormData -> name -> blob -> Maybe filename -> m ()
+appendBlob self name blob filename
+  = liftIO $ js_append self (toJSString name) (unBlob $ toBlob blob) $
+                Nullable $ pToJSVal $ maybe (toJSString "blob") toJSString filename
+
+-- | <https://developer.mozilla.org/en-US/docs/Web/API/FormData/append Mozilla FormData.append documentation>
+appendFile
+  :: (MonadIO m, ToJSString name, ToJSString filename)
+  => FormData -> name -> File -> Maybe filename -> m ()
+appendFile self name file filename
+  = liftIO $ do
+      fn <- getName file
+      js_append self (toJSString name) (unFile file) $
+          Nullable $ pToJSVal $ maybe (fn :: JSString) toJSString filename

--- a/src/GHCJS/DOM/JSFFI/FormData.hs
+++ b/src/GHCJS/DOM/JSFFI/FormData.hs
@@ -2,47 +2,39 @@
 module GHCJS.DOM.JSFFI.FormData (
     module Generated
   , js_append
+  , js_append3
   , append
   , appendBlob
-  , appendFile
 ) where
 
-import Prelude hiding (appendFile)
 import Control.Monad.IO.Class (MonadIO(..))
 
 import GHCJS.Types (JSVal, JSString)
 import GHCJS.Marshal.Internal (PToJSVal(..))
-import GHCJS.Foreign (jsUndefined)
 import GHCJS.DOM.Types
 
 import GHCJS.DOM.JSFFI.Generated.FormData as Generated hiding (js_append, append)
 
-
-maybeToOptional :: PToJSVal a => Maybe a -> JSVal
-maybeToOptional (Just a) = pToJSVal a
-maybeToOptional Nothing = jsUndefined
-
+foreign import javascript unsafe "$1[\"append\"]($2, $3)"
+        js_append :: FormData -> JSString -> JSVal -> IO ()
 
 foreign import javascript unsafe "$1[\"append\"]($2, $3, $4)"
-        js_append :: FormData -> JSString -> JSVal -> JSVal -> IO ()
+        js_append3 :: FormData -> JSString -> JSVal -> JSString -> IO ()
 
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/FormData/append Mozilla FormData.append documentation>
 append
   :: (MonadIO m, ToJSString name, ToJSString str)
   => FormData -> name -> str -> m ()
 append self name str
-  = liftIO $ js_append self (toJSString name) (pToJSVal str) jsUndefined
+  = liftIO $ js_append self (toJSString name) (pToJSVal str)
 
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/FormData/append Mozilla FormData.append documentation>
 appendBlob
   :: (MonadIO m, ToJSString name, IsBlob blob, ToJSString filename)
   => FormData -> name -> blob -> Maybe filename -> m ()
-appendBlob self name blob filename
-  = liftIO $ js_append self (toJSString name) (unBlob $ toBlob blob) $ maybeToOptional $ toJSString <$> filename
-
--- | <https://developer.mozilla.org/en-US/docs/Web/API/FormData/append Mozilla FormData.append documentation>
-appendFile
-  :: (MonadIO m, ToJSString name, ToJSString filename)
-  => FormData -> name -> File -> Maybe filename -> m ()
-appendFile self name file filename
-  = liftIO $ js_append self (toJSString name) (unFile file) $ maybeToOptional $ toJSString <$> filename
+appendBlob self name blob mfilename
+  = let jsname = toJSString name
+        jsblob = unBlob $ toBlob blob
+    in liftIO $ case mfilename of
+         Just filename -> js_append3 self jsname jsblob $ toJSString filename
+         Nothing -> js_append self jsname jsblob


### PR DESCRIPTION
`FormData.append` [can take a Blob](https://developer.mozilla.org/en-US/docs/Web/API/FormData/append) (including subclasses like File). `GHCJS.DOM.FormData.append` currently only accepts Strings - due to [outdated spec](https://github.com/WebKit/webkit/blob/master/Source/WebCore/html/DOMFormData.idl).

This together with `GHCJS.DOM.XMLHttpRequest.sendFormData` allows file uploads as described [here](https://developer.mozilla.org/en-US/docs/Web/API/FormData/Using_FormData_Objects). Example:

```haskell
module Main where

import GHCJS.Types (JSString)

import           GHCJS.DOM (currentDocument)
import           GHCJS.DOM.Document (getElementById)
import qualified GHCJS.DOM.Element as E
import           GHCJS.DOM.EventM (on)
import qualified GHCJS.DOM.FileList as FL
import           GHCJS.DOM.HTMLInputElement (getFiles, castToHTMLInputElement)
import qualified GHCJS.DOM.FormData as FD
import qualified GHCJS.DOM.XMLHttpRequest as X

main :: IO ()
main = do
  Just doc <- currentDocument
  Just e <- getElementById doc "fu"
  fu <- castToHTMLInputElement e
  Just btn <- getElementById doc "btn"
  btn `on` E.click $ do
    Just files <- getFiles fu
    Just f <- FL.item files 0
    fd <- FD.newFormData Nothing
    FD.appendFile fd "file" f (Nothing :: Maybe JSString)
    xhr <- X.newXMLHttpRequest
    X.open xhr "POST" "http://localhost:8000/upload" True "" ""
    X.sendFormData xhr fd
  return ()

```
```html
<!DOCTYPE html>
<html>
  <head>
    <script language="javascript" src="rts.js"></script>
    <script language="javascript" src="lib.js"></script>
    <script language="javascript" src="out.js"></script>
  </head>
  <body>
    <input type="file" id="fu">
    <button type="button" id="btn">Upload</button>
  </body>
  <script language="javascript" src="runmain.js" defer></script>
</html>
```
Any suggestions welcome.

Edit:

Hold on a sec on this. I just noticed two problems:
* passing null is not always the same as not passing an argument (?), apparently in that case we may want undefined
* it is not needed to manually specify the defaults - as long as there is no filename argument or it's undefined

This seems related: https://github.com/ghcjs/ghcjs-dom/issues/32