### PR TITLE
Relax cabal version

### DIFF
--- a/ghcjs-dom-jsffi/ghcjs-dom-jsffi.cabal
+++ b/ghcjs-dom-jsffi/ghcjs-dom-jsffi.cabal
@@ -1,6 +1,6 @@
 name: ghcjs-dom-jsffi
 version: 0.5.0.2
-cabal-version: >=1.24
+cabal-version: >=1.22
 build-type: Simple
 license: MIT
 license-file: LICENSE


### PR DESCRIPTION
Allows for building with `7.10.3`, otherwise nixpkgs ghcjs version rejects this.