### PR TITLE
RTCPeerConnection correction

### DIFF
--- a/ghcjs-dom-jsffi/ghcjs-dom-jsffi.cabal
+++ b/ghcjs-dom-jsffi/ghcjs-dom-jsffi.cabal
@@ -1,5 +1,5 @@
 name: ghcjs-dom-jsffi
-version: 0.7.0.2
+version: 0.7.0.3
 cabal-version: >=1.24
 build-type: Simple
 license: MIT

--- a/ghcjs-dom-jsffi/src/GHCJS/DOM/JSFFI/RTCPeerConnection.hs
+++ b/ghcjs-dom-jsffi/src/GHCJS/DOM/JSFFI/RTCPeerConnection.hs
@@ -38,7 +38,7 @@ foreign import javascript interruptible
 
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection#createOffer Mozilla webkitRTCPeerConnection.createOffer documentation>
 createOffer' :: MonadIO m => RTCPeerConnection -> Maybe Dictionary -> m (Either DOMError RTCSessionDescription)
-createOffer' self offerOptions = liftIO . IO $ \s# -> 
+createOffer' self offerOptions = liftIO . IO $ \s# ->
     case js_createOffer self (maybeToNullable offerOptions) s# of
         (# s2#, False, error #) -> (# s2#, Left  (DOMError              (JSVal error)) #)
         (# s2#, True,  d     #) -> (# s2#, Right (RTCSessionDescription (JSVal d    )) #)
@@ -55,7 +55,7 @@ createAnswer' :: MonadIO m => RTCPeerConnection -> Maybe Dictionary -> m (Either
 createAnswer' self answerOptions = liftIO . IO $ \s# ->
     case js_createOffer self (maybeToNullable answerOptions) s# of
         (# s2#, False, error #) -> (# s2#, Left  (DOMError              (JSVal error)) #)
-        (# s2#, True,  d     #) -> (# s2#, Right (RTCS essionDescription (JSVal d    )) #)
+        (# s2#, True,  d     #) -> (# s2#, Right (RTCSessionDescription (JSVal d    )) #)
 
 createAnswer :: MonadIO m => RTCPeerConnection -> Maybe Dictionary -> m RTCSessionDescription
 createAnswer self answerOptions = createAnswer' self answerOptions >>= either throwDOMErrorException return

--- a/ghcjs-dom-jsffi/src/GHCJS/DOM/JSFFI/RTCPeerConnection.hs
+++ b/ghcjs-dom-jsffi/src/GHCJS/DOM/JSFFI/RTCPeerConnection.hs
@@ -25,7 +25,12 @@ import GHCJS.Prim (JSVal(..))
 import GHCJS.DOM.Types
 
 import GHCJS.DOM.JSFFI.DOMError (throwDOMErrorException)
-import GHCJS.DOM.JSFFI.Generated.Geolocation as Generated hiding (js_getCurrentPosition, getCurrentPosition)
+import GHCJS.DOM.JSFFI.Generated.RTCPeerConnection as Generated hiding (
+    js_createOffer, createOffer
+  , js_createAnswer, createAnswer
+  , js_setLocalDescription, setLocalDescription
+  , js_setRemoteDescription, setRemoteDescription
+)
 
 foreign import javascript interruptible
     "$1[\"createOffer\"](function(d) { $c(true, d); }, function(e) { $c(false, e); }, $2);" js_createOffer ::
@@ -33,7 +38,7 @@ foreign import javascript interruptible
 
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection#createOffer Mozilla webkitRTCPeerConnection.createOffer documentation>
 createOffer' :: MonadIO m => RTCPeerConnection -> Maybe Dictionary -> m (Either DOMError RTCSessionDescription)
-createOffer' self offerOptions = liftIO . IO $ \s# ->
+createOffer' self offerOptions = liftIO . IO $ \s# -> 
     case js_createOffer self (maybeToNullable offerOptions) s# of
         (# s2#, False, error #) -> (# s2#, Left  (DOMError              (JSVal error)) #)
         (# s2#, True,  d     #) -> (# s2#, Right (RTCSessionDescription (JSVal d    )) #)
@@ -50,7 +55,7 @@ createAnswer' :: MonadIO m => RTCPeerConnection -> Maybe Dictionary -> m (Either
 createAnswer' self answerOptions = liftIO . IO $ \s# ->
     case js_createOffer self (maybeToNullable answerOptions) s# of
         (# s2#, False, error #) -> (# s2#, Left  (DOMError              (JSVal error)) #)
-        (# s2#, True,  d     #) -> (# s2#, Right (RTCSessionDescription (JSVal d    )) #)
+        (# s2#, True,  d     #) -> (# s2#, Right (RTCS essionDescription (JSVal d    )) #)
 
 createAnswer :: MonadIO m => RTCPeerConnection -> Maybe Dictionary -> m RTCSessionDescription
 createAnswer self answerOptions = createAnswer' self answerOptions >>= either throwDOMErrorException return

--- a/ghcjs-dom/ghcjs-dom.cabal
+++ b/ghcjs-dom/ghcjs-dom.cabal
@@ -1,5 +1,5 @@
 name: ghcjs-dom
-version: 0.7.0.2
+version: 0.7.0.3
 cabal-version: >=1.24
 build-type: Simple
 license: MIT
@@ -36,7 +36,7 @@ library
     buildable: True
 
     if (impl(ghcjs) && flag(jsffi))
-        build-depends: ghcjs-dom-jsffi ==0.7.0.2
+        build-depends: ghcjs-dom-jsffi ==0.7.0.3
     else
         if flag(webkit)
             build-depends: ghcjs-dom-webkit ==0.7.0.1


### PR DESCRIPTION
I noticed that RTCPeerConnection was incorrectly importing and reexporting Generated.Geolocation instead of Generated.RTCPeerLocation. I've changed it to import all Generated methods except those exported by the non-generated  file.

I don't know if this is expected behaviour - the generated set has all of these functions, but they have different type signature.

Also, I noticed, but haven't changed, that getStats is defined but not exported in the non-generated version of RTCPeerConnection