### PR TITLE
Make Generated import non qualified (make Generated module accessible)

### DIFF
--- a/ghcjs-dom-jsffi/src/GHCJS/DOM/JSFFI/RTCPeerConnection.hs
+++ b/ghcjs-dom-jsffi/src/GHCJS/DOM/JSFFI/RTCPeerConnection.hs
@@ -31,7 +31,7 @@ import GHCJS.Prim (JSVal(..))
 import GHCJS.DOM.Types
 
 import GHCJS.DOM.JSFFI.DOMError (throwDOMErrorException)
-import qualified GHCJS.DOM.JSFFI.Generated.RTCPeerConnection as Generated hiding (
+import GHCJS.DOM.JSFFI.Generated.RTCPeerConnection as Generated hiding (
     js_createOffer, createOffer
   , js_createAnswer, createAnswer
   , js_setLocalDescription, setLocalDescription


### PR DESCRIPTION
I don't know what is supposed to happen if one exports a qualifiedly
imported module, but what does happen is that the names in the exported
module are not (easily) accessible.

A google search got me no results to exports of qualified imports, but
simply dropping qualified made it work for me.