### PR TITLE
Update package qualified imports for ghc 9

### DIFF
--- a/ghcjs-dom/src/GHCJS/DOM/Document.hs
+++ b/ghcjs-dom/src/GHCJS/DOM/Document.hs
@@ -27,8 +27,8 @@ import GHCJS.DOM.Element (setAttribute, getAttribute)
 import qualified "ghcjs-dom-jsffi" GHCJS.DOM.Document as Raw (createElement, createElement_, createElementNS, createElementNS_)
 import "ghcjs-dom-jsffi" GHCJS.DOM.Document as Export hiding (createElement, createElement_, createElementNS, createElementNS_)
 #else
-import qualified "jsaddle-dom" GHCJS.DOM.Document as Raw (createElement, createElement_, createElementNS, createElementNS_)
-import "jsaddle-dom" GHCJS.DOM.Document as Export hiding (createElement, createElement_, createElementNS, createElementNS_)
+import qualified "ghcjs-jsaddle-dom" GHCJS.DOM.Document as Raw (createElement, createElement_, createElementNS, createElementNS_)
+import "ghcjs-jsaddle-dom" GHCJS.DOM.Document as Export hiding (createElement, createElement_, createElementNS, createElementNS_)
 #endif
 
 

--- a/ghcjs-dom/src/GHCJS/DOM/Document.hs
+++ b/ghcjs-dom/src/GHCJS/DOM/Document.hs
@@ -27,8 +27,8 @@ import GHCJS.DOM.Element (setAttribute, getAttribute)
 import qualified "ghcjs-dom-jsffi" GHCJS.DOM.Document as Raw (createElement, createElement_, createElementNS, createElementNS_)
 import "ghcjs-dom-jsffi" GHCJS.DOM.Document as Export hiding (createElement, createElement_, createElementNS, createElementNS_)
 #else
-import qualified "ghcjs-jsaddle-dom" GHCJS.DOM.Document as Raw (createElement, createElement_, createElementNS, createElementNS_)
-import "ghcjs-jsaddle-dom" GHCJS.DOM.Document as Export hiding (createElement, createElement_, createElementNS, createElementNS_)
+import qualified "ghcjs-dom-jsaddle" GHCJS.DOM.Document as Raw (createElement, createElement_, createElementNS, createElementNS_)
+import "ghcjs-dom-jsaddle" GHCJS.DOM.Document as Export hiding (createElement, createElement_, createElementNS, createElementNS_)
 #endif
 
 
@@ -75,8 +75,8 @@ createElementNS_ doc namespaceURI qualifiedName = void $ createElementNS doc nam
 import "ghcjs-dom-jsffi" GHCJS.DOM.Document (createElement, createElement_, createElementNS, createElementNS_)
 import "ghcjs-dom-jsffi" GHCJS.DOM.Document as Export hiding (createElement, createElement_, createElementNS, createElementNS_)
 #else
-import "ghcjs-jsaddle-dom" GHCJS.DOM.Document (createElement, createElement_, createElementNS, createElementNS_)
-import "ghcjs-jsaddle-dom" GHCJS.DOM.Document as Export hiding (createElement, createElement_, createElementNS, createElementNS_)
+import "ghcjs-dom-jsaddle" GHCJS.DOM.Document (createElement, createElement_, createElementNS, createElementNS_)
+import "ghcjs-dom-jsaddle" GHCJS.DOM.Document as Export hiding (createElement, createElement_, createElementNS, createElementNS_)
 #endif
 
 #endif

--- a/ghcjs-dom/src/GHCJS/DOM/Document.hs
+++ b/ghcjs-dom/src/GHCJS/DOM/Document.hs
@@ -75,8 +75,8 @@ createElementNS_ doc namespaceURI qualifiedName = void $ createElementNS doc nam
 import "ghcjs-dom-jsffi" GHCJS.DOM.Document (createElement, createElement_, createElementNS, createElementNS_)
 import "ghcjs-dom-jsffi" GHCJS.DOM.Document as Export hiding (createElement, createElement_, createElementNS, createElementNS_)
 #else
-import "jsaddle-dom" GHCJS.DOM.Document (createElement, createElement_, createElementNS, createElementNS_)
-import "jsaddle-dom" GHCJS.DOM.Document as Export hiding (createElement, createElement_, createElementNS, createElementNS_)
+import "ghcjs-jsaddle-dom" GHCJS.DOM.Document (createElement, createElement_, createElementNS, createElementNS_)
+import "ghcjs-jsaddle-dom" GHCJS.DOM.Document as Export hiding (createElement, createElement_, createElementNS, createElementNS_)
 #endif
 
 #endif


### PR DESCRIPTION
Trying my hand at writing up the fix mentioned by maralorn here: https://github.com/ghcjs/ghcjs-dom/issues/101. When upgrading to GHC 9.0.2 compilation failed because some of the qualified imports were out of date. I have updated them.