### PR TITLE
Use new JS backend syntax in js_send foreign import

### DIFF
--- a/ghcjs-dom-javascript/src/GHCJS/DOM/JSFFI/XMLHttpRequest.hs
+++ b/ghcjs-dom-javascript/src/GHCJS/DOM/JSFFI/XMLHttpRequest.hs
@@ -32,7 +32,7 @@ throwXHRError 0 = return ()
 throwXHRError 1 = throwIO XHRAborted
 throwXHRError 2 = throwIO XHRError
 
-foreign import javascript interruptible "h$dom$sendXHR($1, $2, $c);" js_send :: XMLHttpRequest -> JSVal -> IO Int
+foreign import javascript interruptible "((x, y, c) => { h$dom$sendXHR(x, y, c); } )" js_send :: XMLHttpRequest -> JSVal -> IO Int
 
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#send() Mozilla XMLHttpRequest.send documentation>
 send :: (MonadIO m) => XMLHttpRequest -> m ()

--- a/ghcjs-dom-javascript/src/GHCJS/DOM/JSFFI/XMLHttpRequest.hs
+++ b/ghcjs-dom-javascript/src/GHCJS/DOM/JSFFI/XMLHttpRequest.hs
@@ -32,7 +32,7 @@ throwXHRError 0 = return ()
 throwXHRError 1 = throwIO XHRAborted
 throwXHRError 2 = throwIO XHRError
 
-foreign import javascript interruptible "((x, y, c) => { h$dom$sendXHR(x, y, c); } )" js_send :: XMLHttpRequest -> JSVal -> IO Int
+foreign import javascript interruptible "h$dom$sendXHR" js_send :: XMLHttpRequest -> JSVal -> IO Int
 
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#send() Mozilla XMLHttpRequest.send documentation>
 send :: (MonadIO m) => XMLHttpRequest -> m ()

--- a/ghcjs-dom-jsffi/ghcjs-dom-jsffi.cabal
+++ b/ghcjs-dom-jsffi/ghcjs-dom-jsffi.cabal
@@ -24,7 +24,7 @@ library
     build-depends: base <5,
                    transformers >=0.2 && <0.7,
                    text >= 0.11.0.6 && < 2.2,
-                   ghcjs-base >=0.2.0.0 && <0.3,
+                   ghcjs-base >=0.2.0.0,
                    ghc-prim
 
     default-language: Haskell2010


### PR DESCRIPTION
I believe that some `foreign import`s haven't been updated to use the new GHC JS backend syntax.

I needed to make this change to get `servant-jsaddle` to work.

Have I done the correct thing here? I'm particularly dubious about replacing the `$c` argument with a named variable `c`.

If this is correct, I can make these changes throughout the codebase.