### PR TITLE
Add upper bound on ghcjs-base back into -jsffi

### DIFF
--- a/ghcjs-dom-jsffi/ghcjs-dom-jsffi.cabal
+++ b/ghcjs-dom-jsffi/ghcjs-dom-jsffi.cabal
@@ -24,7 +24,7 @@ library
     build-depends: base <5,
                    transformers >=0.2 && <0.7,
                    text >= 0.11.0.6 && < 2.2,
-                   ghcjs-base >=0.2.0.0,
+                   ghcjs-base >=0.2.0.0 && <0.3,
                    ghc-prim
 
     default-language: Haskell2010


### PR DESCRIPTION
PR #105 relaxed the `ghcjs-base` bound on `ghcjs-dom-jsffi`, but the fix was for `ghcjs-dom-javascript`.  We should not be using both `ghcjs-dom-jsffi` and `ghcjs-dom-javascript` at the same time.

Packages should either depend on `ghcjs-dom` only (and let it choose the correct implementation library) or do something like:

```
if impl(ghc >9)
  build-depends: ghcjs-dom-javascript
else
  build-depends: ghcjs-dom-jsffi
```