### PR TITLE
Fix syntax for ghc js backend

### DIFF
--- a/ghcjs-dom-javascript/src/GHCJS/DOM/Types.hs
+++ b/ghcjs-dom-javascript/src/GHCJS/DOM/Types.hs
@@ -1058,7 +1058,7 @@ strictEqual a b = do
 #ifdef __GHCJS__
 foreign import javascript unsafe "h$isInstanceOf $1 $2"
 #else
-foreign import javascript unsafe "(($1, $2) => h$isInstanceOf($1, $2))"
+foreign import javascript unsafe "h$isInstanceOf"
 #endif
     typeInstanceIsA' :: JSVal -> JSVal -> Bool
 

--- a/ghcjs-dom-javascript/src/GHCJS/DOM/Types.hs
+++ b/ghcjs-dom-javascript/src/GHCJS/DOM/Types.hs
@@ -1055,7 +1055,11 @@ strictEqual a b = do
     bval <- toJSVal b
     return $ js_eq aval bval
 
+#ifdef __GHCJS__
 foreign import javascript unsafe "h$isInstanceOf $1 $2"
+#else
+foreign import javascript unsafe "(($1, $2) => h$isInstanceOf($1, $2))"
+#endif
     typeInstanceIsA' :: JSVal -> JSVal -> Bool
 
 typeInstanceIsA o (GType t) = typeInstanceIsA' o t

--- a/ghcjs-dom-javascript/src/GHCJS/DOM/Types.hs
+++ b/ghcjs-dom-javascript/src/GHCJS/DOM/Types.hs
@@ -1044,10 +1044,18 @@ propagateGError = id
 
 newtype GType = GType JSVal
 
+#ifdef __GHCJS__
 foreign import javascript unsafe "$r = $1.name;" gTypeToString :: GType -> JSString
+#else
+foreign import javascript unsafe "(($1) => $1.name)" gTypeToString :: GType -> JSString
+#endif
 
 foreign import javascript unsafe
+#ifdef __GHCJS__
   "$1===$2" js_eq :: JSVal -> JSVal -> Bool
+#else
+  "(($1, $2) => $1===$2)" js_eq :: JSVal -> JSVal -> Bool
+#endif
 
 strictEqual :: (ToJSVal a, ToJSVal b) => a -> b -> JSM Bool
 strictEqual a b = do


### PR DESCRIPTION
Perhaps it is not the only location where syntax needs to be updated, but at least this change fixes js errors in my simple reflex application compiled with ghc-9.8's js backend.